### PR TITLE
[koldstore] Details

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,6 @@ as an example, put up a PR with a link! Make sure to use the new [pull request t
 
 ## Scaling & Storage
 
-- [kalamdb/koldstore](https://github.com/kalamdb/koldstore): PostgreSQL tiered-storage that moves historical rows to Parquet while keeping the original table fully queryable and supporting updates and deletes.
 - [Snowflake-Labs/pg_lake](https://github.com/Snowflake-Labs/pg_lake): Enables leveraging Postgres as a standalone lakehouse system. It supports transactions and queries on Iceberg tables, enabling it to directly work with raw data files in object stores like S3.
 - [supabase/supavisor](https://github.com/supabase/supavisor)
 - [pg-sharding/spqr](https://github.com/pg-sharding/spqr)
@@ -262,6 +261,7 @@ as an example, put up a PR with a link! Make sure to use the new [pull request t
 - [pgbouncer/pgbouncer](https://github.com/pgbouncer/pgbouncer): Lightweight connection pooler for PostgreSQL. See also: [Scaling Postgres Connections with PgBouncer](https://planetscale.com/blog/scaling-postgres-connections-with-pgbouncer).
 - [orioledb.com/](https://www.orioledb.com): OrioleDB is a PostgreSQL extension that combines the advantages of both on-disk and in-memory engines. It uses PostgreSQL pluggable storage to increase performance and cut costs.
 - [How Cloudflare Achieved 55 Million Requests per Second with Just 15 PostgreSQL Clusters!](https://levelup.gitconnected.com/how-cloudflare-achieved-55-million-requests-per-second-with-just-15-postgresql-clusters-2d8a28ffd100)
+- [kalamdb/koldstore](https://github.com/kalamdb/koldstore): PostgreSQL tiered-storage that moves historical rows to Parquet while keeping the original table fully queryable and supporting updates and deletes.
 
 ## User Interfaces & Dashboards
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ as an example, put up a PR with a link! Make sure to use the new [pull request t
 
 ## Events, Replication, CDC
 
+- [KalamDB](https://kalamdb.org): SQL-first realtime state database for AI agents (USER isolation, live subscriptions) with a PostgreSQL bridge via [pg_kalam](https://github.com/kalamdb/KalamDB).
 - [aws/pgactive](https://github.com/aws/pgactive): Replication extension for creating an active-active database by AWS.
 - [xataio/pgstream](https://github.com/xataio/pgstream): CDC command-line tool and library that offers Postgres replication support with DDL changes to any provided output.
 - [electric-sql/electric](https://github.com/electric-sql/electric): HTTP API that enables synching [Shapes](https://electric-sql.com/docs/guides/shapes) (i.e. segments) of a Postgres database. It's like GraphQL for Postgres databases.
@@ -254,6 +255,7 @@ as an example, put up a PR with a link! Make sure to use the new [pull request t
 
 ## Scaling & Storage
 
+- [kalamdb/koldstore](https://github.com/kalamdb/koldstore): Open-source PostgreSQL tiered-storage extension — hot rows stay in the heap, history flushes to Parquet, one-table queries ([kalamdb.org/koldstore](https://kalamdb.org/koldstore)).
 - [Snowflake-Labs/pg_lake](https://github.com/Snowflake-Labs/pg_lake): Enables leveraging Postgres as a standalone lakehouse system. It supports transactions and queries on Iceberg tables, enabling it to directly work with raw data files in object stores like S3.
 - [supabase/supavisor](https://github.com/supabase/supavisor)
 - [pg-sharding/spqr](https://github.com/pg-sharding/spqr)

--- a/README.md
+++ b/README.md
@@ -197,7 +197,6 @@ as an example, put up a PR with a link! Make sure to use the new [pull request t
 
 ## Events, Replication, CDC
 
-- [KalamDB](https://kalamdb.org): SQL-first realtime state database for AI agents (USER isolation, live subscriptions) with a PostgreSQL bridge via [pg_kalam](https://github.com/kalamdb/KalamDB).
 - [aws/pgactive](https://github.com/aws/pgactive): Replication extension for creating an active-active database by AWS.
 - [xataio/pgstream](https://github.com/xataio/pgstream): CDC command-line tool and library that offers Postgres replication support with DDL changes to any provided output.
 - [electric-sql/electric](https://github.com/electric-sql/electric): HTTP API that enables synching [Shapes](https://electric-sql.com/docs/guides/shapes) (i.e. segments) of a Postgres database. It's like GraphQL for Postgres databases.
@@ -255,7 +254,7 @@ as an example, put up a PR with a link! Make sure to use the new [pull request t
 
 ## Scaling & Storage
 
-- [kalamdb/koldstore](https://github.com/kalamdb/koldstore): Open-source PostgreSQL tiered-storage extension — hot rows stay in the heap, history flushes to Parquet, one-table queries ([kalamdb.org/koldstore](https://kalamdb.org/koldstore)).
+- [kalamdb/koldstore](https://github.com/kalamdb/koldstore): PostgreSQL tiered-storage that moves historical rows to Parquet while keeping the original table fully queryable and supporting updates and deletes.
 - [Snowflake-Labs/pg_lake](https://github.com/Snowflake-Labs/pg_lake): Enables leveraging Postgres as a standalone lakehouse system. It supports transactions and queries on Iceberg tables, enabling it to directly work with raw data files in object stores like S3.
 - [supabase/supavisor](https://github.com/supabase/supavisor)
 - [pg-sharding/spqr](https://github.com/pg-sharding/spqr)


### PR DESCRIPTION
# koldstore Details

## Type of Change
- [x] New tool
- [ ] New section
- [ ] Editing details of an existing tool or section

## Affiliation (if applicable)

Project maintainer.

## Description

[kalamdb/koldstore](https://github.com/kalamdb/koldstore): PostgreSQL tiered-storage that moves historical rows to Parquet while keeping the original table fully queryable and supporting updates and deletes.